### PR TITLE
feat: add Brazilian PII patterns (CPF, CNPJ, phone)

### DIFF
--- a/src/argus_redact/glue/redact.py
+++ b/src/argus_redact/glue/redact.py
@@ -24,6 +24,7 @@ _LANG_PATTERNS = {
     "de": "argus_redact.lang.de.patterns",
     "uk": "argus_redact.lang.uk.patterns",
     "in": "argus_redact.lang.in_.patterns",
+    "br": "argus_redact.lang.br.patterns",
 }
 
 _LANG_NER_ADAPTERS = {

--- a/src/argus_redact/lang/br/__init__.py
+++ b/src/argus_redact/lang/br/__init__.py
@@ -1,0 +1,2 @@
+LANG_CODE = "br"
+LANG_NAME = "Brazilian Portuguese"

--- a/src/argus_redact/lang/br/patterns.py
+++ b/src/argus_redact/lang/br/patterns.py
@@ -1,0 +1,69 @@
+"""Brazilian regex patterns for Layer 1 PII detection."""
+
+
+def _validate_cpf(value: str) -> bool:
+    """Validate CPF (Cadastro de Pessoas Físicas) check digits."""
+    digits = [int(c) for c in value if c.isdigit()]
+    if len(digits) != 11 or len(set(digits)) == 1:
+        return False
+
+    # First check digit
+    total = sum(d * w for d, w in zip(digits[:9], range(10, 1, -1)))
+    remainder = total % 11
+    if digits[9] != (0 if remainder < 2 else 11 - remainder):
+        return False
+
+    # Second check digit
+    total = sum(d * w for d, w in zip(digits[:10], range(11, 1, -1)))
+    remainder = total % 11
+    if digits[10] != (0 if remainder < 2 else 11 - remainder):
+        return False
+
+    return True
+
+
+def _validate_cnpj(value: str) -> bool:
+    """Validate CNPJ (Cadastro Nacional da Pessoa Jurídica) check digits."""
+    digits = [int(c) for c in value if c.isdigit()]
+    if len(digits) != 14 or len(set(digits)) == 1:
+        return False
+
+    # First check digit
+    weights = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    total = sum(d * w for d, w in zip(digits[:12], weights))
+    remainder = total % 11
+    if digits[12] != (0 if remainder < 2 else 11 - remainder):
+        return False
+
+    # Second check digit
+    weights = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    total = sum(d * w for d, w in zip(digits[:13], weights))
+    remainder = total % 11
+    if digits[13] != (0 if remainder < 2 else 11 - remainder):
+        return False
+
+    return True
+
+
+PATTERNS = [
+    {
+        "type": "cpf",
+        "label": "[CPF]",
+        "pattern": r"(?<!\d)\d{3}\.?\d{3}\.?\d{3}-?\d{2}(?!\d)",
+        "validate": _validate_cpf,
+        "description": "Brazilian CPF (Cadastro de Pessoas Físicas)",
+    },
+    {
+        "type": "cnpj",
+        "label": "[CNPJ]",
+        "pattern": r"(?<!\d)\d{2}\.?\d{3}\.?\d{3}/?\d{4}-?\d{2}(?!\d)",
+        "validate": _validate_cnpj,
+        "description": "Brazilian CNPJ (Cadastro Nacional da Pessoa Jurídica)",
+    },
+    {
+        "type": "phone",
+        "label": "[Telefone]",
+        "pattern": r"(?:\+55\s?)?\(?\d{2}\)?\s?\d{4,5}-?\d{4}(?!\d)",
+        "description": "Brazilian phone number",
+    },
+]

--- a/tests/fixtures/br_patterns.json
+++ b/tests/fixtures/br_patterns.json
@@ -1,0 +1,69 @@
+[
+    {
+      "id": "cpf_with_dots",
+      "input": "CPF: 529.982.247-25",
+      "should_match": true,
+      "type": "cpf",
+      "expected_text": "529.982.247-25",
+      "description": "Valid CPF with formatting"
+    },
+    {
+      "id": "cpf_digits_only",
+      "input": "CPF 52998224725",
+      "should_match": true,
+      "type": "cpf",
+      "expected_text": "52998224725",
+      "description": "Valid CPF without formatting"
+    },
+    {
+      "id": "cpf_invalid_check_digit",
+      "input": "CPF: 529.982.247-99",
+      "should_match": false,
+      "type": "cpf",
+      "description": "Invalid CPF check digits"
+    },
+    {
+      "id": "cpf_all_same_digits",
+      "input": "111.111.111-11",
+      "should_match": false,
+      "type": "cpf",
+      "description": "All same digits should be rejected"
+    },
+    {
+      "id": "cnpj_valid",
+      "input": "CNPJ: 11.222.333/0001-81",
+      "should_match": true,
+      "type": "cnpj",
+      "expected_text": "11.222.333/0001-81",
+      "description": "Valid CNPJ with formatting"
+    },
+    {
+      "id": "cnpj_invalid",
+      "input": "CNPJ: 11.222.333/0001-99",
+      "should_match": false,
+      "type": "cnpj",
+      "description": "Invalid CNPJ check digits"
+    },
+    {
+      "id": "phone_with_country_code",
+      "input": "Tel: +55 (11) 99876-5432",
+      "should_match": true,
+      "type": "phone",
+      "expected_text": "+55 (11) 99876-5432",
+      "description": "Brazilian mobile with country code"
+    },
+    {
+      "id": "phone_without_country_code",
+      "input": "Ligar: (21) 3456-7890",
+      "should_match": true,
+      "type": "phone",
+      "description": "Brazilian landline without country code"
+    },
+    {
+      "id": "plain_text",
+      "input": "Bom dia",
+      "should_match": false,
+      "type": "cpf",
+      "description": "No PII"
+    }
+  ]

--- a/tests/lang/test_br.py
+++ b/tests/lang/test_br.py
@@ -1,0 +1,29 @@
+"""Tests for Brazilian regex patterns."""
+
+import pytest
+from argus_redact.lang.br.patterns import PATTERNS as BR_PATTERNS
+from argus_redact.lang.shared.patterns import PATTERNS as SHARED_PATTERNS
+from argus_redact.pure.patterns import match_patterns
+
+from tests.conftest import parametrize_examples
+
+ALL_BR_PATTERNS = BR_PATTERNS + SHARED_PATTERNS
+
+
+@pytest.fixture
+def br_patterns():
+    return ALL_BR_PATTERNS
+
+
+class TestBrazilianPatterns:
+    @parametrize_examples("br_patterns.json")
+    def test_should_match_or_reject_when_input(self, br_patterns, example):
+        results = match_patterns(example["input"], br_patterns)
+        typed = [r for r in results if r.type == example["type"]]
+
+        if example["should_match"]:
+            assert len(typed) >= 1, f"Expected match: {example['description']}"
+            if "expected_text" in example:
+                assert any(r.text == example["expected_text"] for r in typed)
+        else:
+            assert len(typed) == 0, f"Should NOT match: {example['description']}"


### PR DESCRIPTION
Add Brazilian Portuguese PII detection patterns with check digit validation.

- CPF (Cadastro de Pessoas Físicas) with MOD 11 validation
- CNPJ (Cadastro Nacional da Pessoa Jurídica) with MOD 11 validation
- Phone numbers (+55 format)
- Test fixtures with positive and negative cases
- Registered in glue/redact.py

Closes #1 